### PR TITLE
Feature/80 Swiper 사용 시 SSR 시점에서 스타일 적용되지 않는 문제 해결

### DIFF
--- a/src/app/(home)/_components/MainCarousel.tsx
+++ b/src/app/(home)/_components/MainCarousel.tsx
@@ -25,8 +25,16 @@ const MainCarousel = ({ type, data }: IMainCarouselProps) => {
       <div className="flex">
         <Swiper
           modules={[Navigation, A11y]}
-          slidesPerView={2.5}
+          slidesPerView={2}
           spaceBetween={2}
+          breakpoints={{
+            500: {
+              slidesPerView: 3,
+            },
+            1200: {
+              slidesPerView: 4,
+            },
+          }}
           className="relative"
         >
           <CarouselArrowButton direction="prev" />

--- a/src/app/(home)/_components/MainCarousel.tsx
+++ b/src/app/(home)/_components/MainCarousel.tsx
@@ -25,16 +25,8 @@ const MainCarousel = ({ type, data }: IMainCarouselProps) => {
       <div className="flex">
         <Swiper
           modules={[Navigation, A11y]}
-          slidesPerView={2}
+          slidesPerView="auto"
           spaceBetween={2}
-          breakpoints={{
-            500: {
-              slidesPerView: 3,
-            },
-            1200: {
-              slidesPerView: 4,
-            },
-          }}
           className="relative"
         >
           <CarouselArrowButton direction="prev" />

--- a/src/app/(home)/_components/MainCarousel.tsx
+++ b/src/app/(home)/_components/MainCarousel.tsx
@@ -27,14 +27,6 @@ const MainCarousel = ({ type, data }: IMainCarouselProps) => {
           modules={[Navigation, A11y]}
           slidesPerView={2.5}
           spaceBetween={2}
-          breakpoints={{
-            768: {
-              slidesPerView: 3.5,
-            },
-            1024: {
-              slidesPerView: 4.5,
-            },
-          }}
           className="relative"
         >
           <CarouselArrowButton direction="prev" />
@@ -42,7 +34,7 @@ const MainCarousel = ({ type, data }: IMainCarouselProps) => {
           {data.map(gathering => (
             <SwiperSlide
               key={gathering.id}
-              className="!ml-[15px] !w-[150px] md:!w-[240px] lg:!w-[260px]"
+              className="!ml-[15px] !w-[150px] first:!ml-0 md:!w-[240px] lg:!w-[260px]"
             >
               <MainCarouselItem gathering={gathering} />
             </SwiperSlide>

--- a/src/app/(home)/_components/MainCarousel.tsx
+++ b/src/app/(home)/_components/MainCarousel.tsx
@@ -26,7 +26,7 @@ const MainCarousel = ({ type, data }: IMainCarouselProps) => {
         <Swiper
           modules={[Navigation, A11y]}
           slidesPerView={2.5}
-          spaceBetween={5}
+          spaceBetween={2}
           breakpoints={{
             768: {
               slidesPerView: 3.5,
@@ -40,7 +40,10 @@ const MainCarousel = ({ type, data }: IMainCarouselProps) => {
           <CarouselArrowButton direction="prev" />
           <CarouselArrowButton direction="next" />
           {data.map(gathering => (
-            <SwiperSlide key={gathering.id}>
+            <SwiperSlide
+              key={gathering.id}
+              className="!ml-[15px] !w-[150px] md:!w-[240px] lg:!w-[260px]"
+            >
               <MainCarouselItem gathering={gathering} />
             </SwiperSlide>
           ))}

--- a/src/app/(home)/_components/MainCarouselContainer.tsx
+++ b/src/app/(home)/_components/MainCarouselContainer.tsx
@@ -5,6 +5,7 @@ import {
 } from "@tanstack/react-query";
 
 import FetchBoundary from "@/components/boundary/FetchBoundary";
+import MainCarouselSkeleton from "@/components/skeletons/MainCarouselSkeleton";
 import { prefetchDeadlineImminentGatherings } from "@/hooks/gathering/useDeadlineImminentGatherings";
 import { prefetchPopularGatherings } from "@/hooks/gathering/usePopularGatherings";
 
@@ -22,18 +23,10 @@ const MainCarouselContainer = async () => {
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
       <section className="flex flex-col gap-20">
-        <FetchBoundary
-          fallback={
-            <div className="h-[100px] w-full bg-red-500">Loading...</div>
-          }
-        >
+        <FetchBoundary fallback={<MainCarouselSkeleton />}>
           <PopularCarousel />
         </FetchBoundary>
-        <FetchBoundary
-          fallback={
-            <div className="h-[100px] w-full bg-red-500">Loading...</div>
-          }
-        >
+        <FetchBoundary fallback={<MainCarouselSkeleton />}>
           <DeadLineCarousel />
         </FetchBoundary>
       </section>

--- a/src/app/(home)/_components/MainPromotion.tsx
+++ b/src/app/(home)/_components/MainPromotion.tsx
@@ -35,7 +35,7 @@ const MainPromotion = ({ type }: IMainPromotionProps) => {
         ) : (
           <p>{"원하는 주제의 모임을 \n 집에서 편하게 즐겨보세요"}</p>
         )}
-        <Link href="/gathering">
+        <Link href={`/gathering?type=${type}`}>
           <Button variant="purple" className="px-12 py-8 text-2xl font-bold">
             {type === "offline"
               ? "오프라인 모임 찾아보기"

--- a/src/components/skeletons/MainCarouselSkeleton.tsx
+++ b/src/components/skeletons/MainCarouselSkeleton.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@/components/ui/Skeleton";
+
+const MainCarouselSkeleton = () => {
+  return (
+    <section className="w-full overflow-hidden">
+      <div className="flex w-[1500px] flex-col gap-5">
+        <Skeleton className="h-[40px] w-[200px]" />
+        <div className="flex">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <div
+              key={index}
+              className="ml-[15px] flex w-[150px] flex-col gap-2 first:ml-0 md:w-[240px] lg:w-[260px]"
+            >
+              <Skeleton className="h-[150px] md:h-[200px] lg:h-[250px]" />
+              <Skeleton className="h-[30px] w-[80%]" />
+              <Skeleton className="h-[20px] w-[50%]" />
+              <Skeleton className="h-[20px] w-[60%]" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MainCarouselSkeleton;


### PR DESCRIPTION
## Swiper SSR 트러블 슈팅

### 문제 상황
SSR 시점에서 Swiper를 사용한 컴포넌트의 레이아웃 쉬프트 현상이 발생했습니다.
CSR로 전환하면 해당 문제가 발생되지 않으나, 현재 컴포넌트가 적용될 곳이 메인페이지이기 때문에 SEO 향상과 빠른 초기 로딩 등을 이유로 SSR을 적용하고자 하였습니다.

### 문제 발생 이유

https://github.com/nolimits4web/swiper/blob/master/src/react/swiper.mjs
swiper의 내부 코드를 살펴보면 mount 될 때, useLayoutEffect를 사용하여 DOM이 업데이트된 직후 레이아웃 시점에 필요한 엘리먼트 요소들을 갖고 계산한 후 페인팅하는 스타일 시스템을 사용하는 것을 알 수 있습니다.

```ts
 // mount swiper
    useIsomorphicLayoutEffect(() => {
      if (externalElRef) {
        externalElRef.current = swiperElRef.current;
      }
      if (!swiperElRef.current) return;
      if (swiperRef.current.destroyed) {
        initSwiper();
      }

      mountSwiper(
        {
          el: swiperElRef.current,
          nextEl: nextElRef.current,
          prevEl: prevElRef.current,
          paginationEl: paginationElRef.current,
          scrollbarEl: scrollbarElRef.current,
          swiper: swiperRef.current,
        },
        swiperParams,
      );

      if (onSwiper && !swiperRef.current.destroyed) onSwiper(swiperRef.current);
      // eslint-disable-next-line
      return () => {
        if (swiperRef.current && !swiperRef.current.destroyed) {
          swiperRef.current.destroy(true, false);
        }
      };
    }, []);
```
https://github.com/nolimits4web/swiper/blob/master/src/react/use-isomorphic-layout-effect.mjs
useIsomorphicLayoutEffect 훅이 SSR 및 CSR일 때 어떻게 분기 처리하고 있나 확인해보았습니다.
```ts
import { useEffect, useLayoutEffect } from 'react';

function useIsomorphicLayoutEffect(callback, deps) {
  // eslint-disable-next-line
  if (typeof window === 'undefined') return useEffect(callback, deps);
  return useLayoutEffect(callback, deps);
}

export { useIsomorphicLayoutEffect };

```

typeof window == 'undefined'로 환경이 서버인지 클라이언트인지 판별하여 서버일때는 useEffect를, useLayoutEffect를 반환해주고 있었습니다.
즉, 이 코드는 브라우저 환경에서만 동작하는 useLayoutEffect가 서버에서 실행되면 발생되는 "useLayoutEffect does nothing on the server" 경고를 방지하기 위한 코드입니다.
하지만 서버 환경일 때 useEffect를 반환한다고 해도 렌더링 후 스타일이 적용되기 때문에 SSR 시점에서 발생되는 레이아웃 쉬프트 문제에 대한 해결방안은 아니었습니다.

정리하자면, Swiper는 useEffect 및 useLayoutEffect를 사용한 스타일 시스템을 적용하여 CSR 시점에 DOM 요소에 직접 스타일을 주입하고 있기 때문에 SSR 시점에 스타일이 적용되지 않아 레이아웃 쉬프트 현상이 발생한 것이었습니다.


### 해결 방안
발생한 문제를 해결하기 위해선 CSR 이전 SSR 시점부터 스타일을 적용할 수 있도록 swiper에서 useEffect 및 useLayoutEffect로 처리하는 스타일을 미리 계산하여 렌더링 할 수 있도록 해야합니다.

https://github.com/nolimits4web/swiper/issues/7577#issuecomment-2626420093
예상 레이아웃에 따라 CSS에서 슬라이드 너비와 여백을 미리 설정했습니다.
이렇게 하면 Swiper의 JavaScript가 슬라이드를 조정하기 전 레이아웃의 스타일을 지정할 수 있습니다. 

또한, CSS를 그냥 사용했을 때 Swiper에서 지정하는 스타일에 대한 영향으로 제대로 적용되지 않기 때문에 !important를 사용하여 Swiper의 스타일보다 우선순위를 높여서 스타일을 덮어씌웠습니다.

```js
<SwiperSlide
              key={gathering.id}
              className="!ml-[15px] !w-[150px] first:!ml-0 md:!w-[240px] lg:!w-[260px]"
            >
              <MainCarouselItem gathering={gathering} />
</SwiperSlide>
```

(﹢
SwiperSlide의 개수만큼 breakpoints가 적용돼서 wrapper의 너비가 계산되어 고정되는데,
이렇게 적용하게 되면 덮어씌운 스타일로 SwiperSilde의 너비가 적용되기 때문에 짤림 현상이 있을 수 있습니다. 
이는 breakpoints를 삭제하고 slidesPerView의 값으로 auto를 사용해서 자동으로 슬라이드의 너비를 계산하도록 하여 짤림 현상을 해결했습니다.)

### 결과

결론적으로 Swiper에서 useEffect 및 useLayoutEffect를 사용하여 CSR 과정에서 스타일을 주입하는 것을 서버 환경에서 미리 처리하게 하여 SSR을 적용하면서도 레이아웃 쉬프트 현상이 일어나지 않도록 해결했습니다.

